### PR TITLE
Todo 35 delete user

### DIFF
--- a/src/api/api.py
+++ b/src/api/api.py
@@ -1,6 +1,11 @@
 from flask import request, jsonify
-from flask_jwt_extended import create_access_token, get_jwt_identity, jwt_required
-from ..config.db_models import db, Todo, User
+from flask_jwt_extended import (
+    create_access_token,
+    get_jwt_identity,
+    jwt_required,
+    get_jwt
+)
+from ..config.db_models import db, Todo, User, BlacklistedToken
 from ..config.db_config import initialize_database
 from .app_factory import create_app
 
@@ -18,7 +23,8 @@ def register():
         return jsonify({"message": "Username already exists"}), 400
 
     try:
-        user = User(username=data['username'])
+        user = User()
+        user.username = data['username']
         user.set_password(data['password'])
         db.session.add(user)
         db.session.commit()
@@ -26,6 +32,7 @@ def register():
     except Exception as e:
         db.session.rollback()
         return jsonify({"message": "Database error occurred"}), 500
+
 
 @app.route('/api/auth/login', methods=['POST'])
 def login():
@@ -42,6 +49,55 @@ def login():
         }), 200
     
     return jsonify({"message": "Invalid username or password"}), 401
+
+
+@app.route('/api/auth/logout', methods=['POST'])
+@jwt_required()
+def logout():
+    jti = get_jwt()['jti']
+    token = BlacklistedToken(jti=jti)
+    db.session.add(token)
+    BlacklistedToken.clean_expired()
+    db.session.commit()
+    return jsonify({"message": "Successfully logged out"}), 200
+
+
+def check_if_token_revoked(jwt_header, jwt_payload):
+    jti = jwt_payload["jti"]
+    token = BlacklistedToken.query.filter_by(jti=jti).first()
+    return token is not None
+
+
+@app.route('/api/auth/delete-account', methods=['POST'])
+@jwt_required()
+def delete_account():
+    current_user_id = int(get_jwt_identity())
+    data = request.get_json()
+
+    # Re-authenticate
+    if not data or not data.get('password'):
+        return jsonify({"message": "Password required for account deletion"}), 400
+
+    user = User.query.get(current_user_id)
+    if not user or not user.check_password(data['password']):
+        return jsonify({"message": "Invalid password"}), 401
+
+    try:
+        # Get the JWT token ID for blacklisting
+        jti = get_jwt()["jti"]
+        # Blacklist the current token
+        token = BlacklistedToken(jti=jti)
+        db.session.add(token)
+
+        # Delete the user (will cascade delete their todos thanks to our model setup)
+        db.session.delete(user)
+        db.session.commit()
+
+        return jsonify({"message": "Account deleted successfully"}), 200
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"message": "Error deleting account"}), 500
+
 
 @app.route('/api/todos', methods=['GET'])
 @jwt_required()
@@ -77,6 +133,7 @@ def create_todo():
     except Exception as e:
         db.session.rollback()
         return jsonify({"message": str(e)}), 500
+
 
 @app.route('/api/todos/<int:todo_id>', methods=['PUT'])
 @jwt_required()

--- a/src/api/app_factory.py
+++ b/src/api/app_factory.py
@@ -1,6 +1,6 @@
 from flask import Flask, jsonify
 from flask_jwt_extended import JWTManager
-from ..config.db_models import db
+from ..config.db_models import db, BlacklistedToken
 from ..config.db_config import Config, initialize_database
 
 
@@ -14,6 +14,12 @@ def create_app():
     # Add JWT configuration
     app.config['JWT_SECRET_KEY'] = Config.JWT_SECRET_KEY
     jwt = JWTManager(app)
+
+    @jwt.token_in_blocklist_loader
+    def check_if_token_revoked(jwt_header, jwt_payload):
+        jti = jwt_payload['jti']
+        token = BlacklistedToken.query.filter_by(jti=jti).first()
+        return token is not None
 
     # Add JWT error handlers
     @jwt.invalid_token_loader

--- a/src/config/db_config.py
+++ b/src/config/db_config.py
@@ -1,6 +1,7 @@
 import os
 from sqlalchemy import inspect
-from .db_models import db
+from .db_setup import db
+from datetime import timedelta
 
 
 class Config:
@@ -8,6 +9,12 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     # Add a secure secret key for JWT
     JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY', 'dev-key-please-change-in-production')
+    JWT_ACCESS_TOKEN_EXPIRES = timedelta(days=1)  # Set tokens to expire after 1 day
+
+    @classmethod
+    def get_token_expires_delta(cls):
+        """Single source of truth for token expiration"""
+        return cls.JWT_ACCESS_TOKEN_EXPIRES
 
 
 def initialize_database(app):

--- a/src/config/db_models.py
+++ b/src/config/db_models.py
@@ -1,9 +1,9 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
-from datetime import datetime, timedelta
-
-db = SQLAlchemy()
+from datetime import datetime
+from .db_config import Config
+from .db_setup import db
 
 
 class User(UserMixin, db.Model):
@@ -31,7 +31,7 @@ class BlacklistedToken(db.Model):
     def clean_expired(cls):
         """Remove tokens that are past their JWT expiration time"""
         # Your JWT expiration time + a small buffer
-        expiration = datetime.utcnow() - timedelta(days=1, hours=1)  # assuming 1 day token life
+        expiration = datetime.utcnow() - Config.get_token_expires_delta()
         cls.query.filter(cls.created_at < expiration).delete()
         db.session.commit()
 

--- a/src/config/db_models.py
+++ b/src/config/db_models.py
@@ -4,18 +4,21 @@ from werkzeug.security import generate_password_hash, check_password_hash
 
 db = SQLAlchemy()
 
+
 class User(UserMixin, db.Model):
     __tablename__ = 'user'
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     password_hash = db.Column(db.String(200), nullable=False)
-    todos = db.relationship('Todo', backref='user', lazy=True)
+    todos = db.relationship('Todo', backref='user', lazy=True,
+                            cascade="all, delete-orphan")
 
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)
 
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)
+
 
 class Todo(db.Model):
     __tablename__ = 'todo'

--- a/src/config/db_models.py
+++ b/src/config/db_models.py
@@ -1,6 +1,7 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
+from datetime import datetime, timedelta
 
 db = SQLAlchemy()
 
@@ -18,6 +19,21 @@ class User(UserMixin, db.Model):
 
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)
+
+
+class BlacklistedToken(db.Model):
+    __tablename__ = 'blacklisted_tokens'
+    id = db.Column(db.Integer, primary_key=True)
+    jti = db.Column(db.String(36), nullable=False, unique=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    @classmethod
+    def clean_expired(cls):
+        """Remove tokens that are past their JWT expiration time"""
+        # Your JWT expiration time + a small buffer
+        expiration = datetime.utcnow() - timedelta(days=1, hours=1)  # assuming 1 day token life
+        cls.query.filter(cls.created_at < expiration).delete()
+        db.session.commit()
 
 
 class Todo(db.Model):

--- a/src/config/db_setup.py
+++ b/src/config/db_setup.py
@@ -1,0 +1,3 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()

--- a/src/webapp/webapp.py
+++ b/src/webapp/webapp.py
@@ -63,8 +63,16 @@ def register():
         logger.error(f"Request error during registration: {str(e)}")
         return jsonify({"message": "Failed to connect to API"}), 500
 
+
 @app.route('/logout')
 def logout():
+    token = get_auth_token()
+    if token:
+        headers = {'Authorization': f'Bearer {token}'}
+        # Try to blacklist the token in the API
+        requests.post(f"{API_URL}/auth/logout", headers=headers)
+
+    # Clear the cookie whether the token blacklisting works or not
     resp = make_response(redirect(url_for('login')))
     resp.delete_cookie('auth_token')
     return resp

--- a/test/api/Catchlist Testing.postman_collection.json
+++ b/test/api/Catchlist Testing.postman_collection.json
@@ -561,6 +561,104 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "Delete Account",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"// Test: Status code is 201",
+							"pm.test(\"Status code is 201\", function () {",
+							"    pm.response.to.have.status(201);",
+							"});",
+							"",
+							"// Test: Response time is less than 500ms",
+							"pm.test(\"Response time is less than 500ms\", function () {",
+							"    pm.expect(pm.response.responseTime).to.be.below(500);",
+							"});",
+							"",
+							"// Test: Response is JSON",
+							"pm.test(\"Response is JSON\", function () {",
+							"    pm.response.to.be.json;",
+							"});",
+							"",
+							"// Test: JSON keys validation",
+							"pm.test(\"Response has expected keys\", function () {",
+							"    let jsonData = pm.response.json();",
+							"    pm.expect(jsonData).to.be.an(\"object\");",
+							"    pm.expect(jsonData).to.have.property(\"id\");",
+							"    pm.expect(jsonData).to.have.property(\"title\");",
+							"    pm.expect(jsonData).to.have.property(\"complete\");",
+							"});",
+							"",
+							"// Test: Verify todo data",
+							"pm.test(\"Todo data is correct\", function () {",
+							"    let expectedTitle = pm.environment.get(\"todo_title\");",
+							"",
+							"    let jsonData = pm.response.json();",
+							"    pm.expect(jsonData.title).to.equal(expectedTitle);",
+							"    pm.expect(jsonData.complete).to.be.false;",
+							"});",
+							"",
+							"// Save the todo ID for later use",
+							"let jsonData = pm.response.json();",
+							"pm.environment.set(\"todo_id\", jsonData.id);"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"// Saving a title to validate after creation",
+							"pm.environment.set(\"todo_title\", \"test todo title\");",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{auth_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "     {\n       \"password\": \"{{session_password}}\"\n     }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{protocol}}://{{host}}{{port}}/api/auth/delete-account",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}{{port}}"
+					],
+					"path": [
+						"api",
+						"auth",
+						"delete-account"
+					]
+				}
+			},
+			"response": []
 		}
 	]
 }

--- a/test/api/test_local.sh
+++ b/test/api/test_local.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+newman run Catchlist\ Testing.postman_collection.json -e Dev-Local.postman_environment.json


### PR DESCRIPTION
Per ticket TODO-35 , there's a new endpoint to delete a user. 

Additionally, auth tokens are now blacklisted once the user logs out, deletes the account, or if the token ages past the expiration limit (one day, configured in db_config.py

Also there's a new test in the postman collection for account deletion (at the end of the suite, so we should be able to run tests forever without gunking up the database with single-use accounts)

Also, this is a breaking change, so we'll need to delete the database on staging and prod before implementing this. 