### PR TITLE
Todo 36 account settings page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ charset-normalizer==3.4.1
 click==8.1.7
 dotenv==0.9.9
 Flask==3.1.0
+flask-cors==5.0.1
 Flask-JWT-Extended==4.6.0
 Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -68,6 +68,19 @@ def check_if_token_revoked(jwt_header, jwt_payload):
     return token is not None
 
 
+@app.route('/api/auth/user-info', methods=['GET'])
+@jwt_required()
+def get_user_info():
+    current_user_id = int(get_jwt_identity())
+    user = User.query.get(current_user_id)
+    if user:
+        return jsonify({
+            "id": user.id,
+            "username": user.username
+        })
+    return jsonify({"message": "User not found"}), 404
+
+
 @app.route('/api/auth/delete-account', methods=['POST'])
 @jwt_required()
 def delete_account():

--- a/src/api/app_factory.py
+++ b/src/api/app_factory.py
@@ -1,5 +1,6 @@
 from flask import Flask, jsonify
 from flask_jwt_extended import JWTManager
+from flask_cors import CORS
 from ..config.db_models import db, BlacklistedToken
 from ..config.db_config import Config, initialize_database
 
@@ -7,6 +8,10 @@ from ..config.db_config import Config, initialize_database
 def create_app():
     app = Flask(__name__)
     app.config.from_object(Config)
+
+    # Without CORS, the webapp and api can't connect when run locally,
+    # as they run on different ports, and that makes them two different places.
+    CORS(app)
 
     # initialize extensions
     db.init_app(app)

--- a/src/webapp/static/js/auth.js
+++ b/src/webapp/static/js/auth.js
@@ -59,10 +59,12 @@ function updateAuthUI() {
     const loginLink = document.getElementById('login-link');
     const registerLink = document.getElementById('register-link');
     const logoutLink = document.getElementById('logout-link');
-    
+    const accountLink = document.getElementById('account-link');
+
     if (loginLink) loginLink.style.display = isLoggedIn ? 'none' : 'block';
     if (registerLink) registerLink.style.display = isLoggedIn ? 'none' : 'block';
     if (logoutLink) logoutLink.style.display = isLoggedIn ? 'block' : 'none';
+    if (accountLink) accountLink.style.display = isLoggedIn ? 'block' : 'none';
 }
 
 // Handle navigation with authentication

--- a/src/webapp/templates/account.html
+++ b/src/webapp/templates/account.html
@@ -1,0 +1,127 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="ui container">
+    <h1 class="ui header">
+        <i class="user cog icon"></i>
+        <div class="content">
+            Account Settings
+            <div class="sub header">Manage your account preferences and settings</div>
+        </div>
+    </h1>
+
+    <div class="ui segments">
+        <!-- Account Info Section -->
+        <div class="ui segment">
+            <h3 class="ui header">Account Information</h3>
+            <div class="ui list">
+                <div class="item">
+                    <i class="user icon"></i>
+                    <div class="content">
+                        <div class="header">Username</div>
+                        <div class="description">{{ username }}</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Danger Zone Section -->
+        <div class="ui red segment">
+            <h3 class="ui red header">
+                <i class="exclamation triangle icon"></i>
+                <div class="content">
+                    Danger Zone
+                    <div class="sub header">Destructive actions that cannot be undone</div>
+                </div>
+            </h3>
+
+            <button class="ui negative button" id="delete-account-btn">
+                <i class="user delete icon"></i>
+                Delete Account
+            </button>
+        </div>
+    </div>
+</div>
+
+<!-- Account Deletion Modal -->
+<div class="ui tiny modal" id="delete-account-modal">
+    <i class="close icon"></i>
+    <div class="header">
+        <i class="exclamation triangle icon"></i>
+        Delete Account Permanently
+    </div>
+    <div class="content">
+        <div class="ui warning message">
+            <div class="header">This action cannot be undone</div>
+            <ul class="list">
+                <li>Your account will be permanently deleted</li>
+                <li>All your todos will be removed</li>
+                <li>You will be immediately logged out</li>
+            </ul>
+        </div>
+        <form class="ui form" id="delete-account-form">
+            <div class="required field">
+                <label>Please enter your password to confirm:</label>
+                <div class="ui input">
+                    <input type="password" name="password" required>
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="actions">
+        <div class="ui cancel button">Cancel</div>
+        <button type="submit" form="delete-account-form" class="ui negative button">
+            Delete My Account
+        </button>
+    </div>
+</div>
+
+<script>
+// Initialize and handle account deletion modal
+$('#delete-account-btn').click(function() {
+    $('#delete-account-modal')
+        .modal({
+            closable: true,
+            onDeny: function() {
+                return true;
+            },
+            onApprove: function() {
+                return false; // Let the form handle submission
+            }
+        })
+        .modal('show');
+});
+
+// Handle account deletion form submission
+$('#delete-account-form').on('submit', function(e) {
+    e.preventDefault();
+
+    const password = this.password.value;
+    const apiUrl = '{{ API_URL }}';  // We'll need to pass this from Flask
+
+    fetch(`${apiUrl}/auth/delete-account`, {
+        method: 'POST',
+        headers: {
+            ...getAuthHeaders(),
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ password: password })
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to delete account');
+        }
+        return response.json();
+    })
+    .then(data => {
+        // Account deleted successfully
+        removeToken(); // Clear the auth token
+        window.location.href = '/login';
+    })
+    .catch(error => {
+        showError('Failed to delete account. Please check your password and try again.');
+    });
+});
+
+</script>
+{% endblock %}

--- a/src/webapp/templates/base.html
+++ b/src/webapp/templates/base.html
@@ -28,6 +28,9 @@
                 <a href="/register" class="item" id="register-link" data-testid="register-link">
                     <i class="user plus icon"></i> Register
                 </a>
+                <a href="/account" class="item" id="account-link" style="display: none;" data-testid="account-link">
+                    <i class="user cog icon"></i> Account
+                </a>
                 <a href="/logout" class="item" id="logout-link" style="display: none;" data-testid="logout-link">
                     <i class="sign out icon"></i> Logout
                 </a>

--- a/src/webapp/webapp.py
+++ b/src/webapp/webapp.py
@@ -64,6 +64,29 @@ def register():
         return jsonify({"message": "Failed to connect to API"}), 500
 
 
+@app.route('/account')
+def account():
+    token = get_auth_token()
+    if not token:
+        return redirect(url_for('login'))
+
+    try:
+        headers = {'Authorization': f'Bearer {token}'}
+        # Get user info from API
+        response = requests.get(f"{API_URL}/auth/user-info", headers=headers)
+        if response.status_code == 200:
+            user_info = response.json()
+            return render_template(
+                "account.html",
+                username=user_info['username'],
+                API_URL=API_URL
+            )
+    except Exception as e:
+        logger.error(f"Error accessing account page: {str(e)}")
+
+    return redirect(url_for('login'))
+
+
 @app.route('/logout')
 def logout():
     token = get_auth_token()


### PR DESCRIPTION
Account page - currently just shows your username and a button to delete your account. May become more useful in the future, but for now we just want the account deletion button on its own page away from general user functionality.

Also adding CORS for the API - when running locally the api and webapp run on different ports, thus are different places as far as that system is concerned. On staging and prod we've got gunicorn reverse-proxying the services to nginx which serves them both on 443, so CORS isn't necessary, but CORS is voluntarily enforced by browsers and coolguy stuff like curl can just ignore it, so it's pretty much only useful in blocking phishing attempts. 

So permissive CORS settings are just as good as restrictive ones. 