### PR TITLE
TODO-38: selenium delete user

### DIFF
--- a/src/webapp/templates/account.html
+++ b/src/webapp/templates/account.html
@@ -35,7 +35,7 @@
                 </div>
             </h3>
 
-            <button class="ui negative button" id="delete-account-btn">
+            <button class="ui negative button" id="delete-account-btn" data-testid="delete-account-btn">
                 <i class="user delete icon"></i>
                 Delete Account
             </button>
@@ -63,14 +63,14 @@
             <div class="required field">
                 <label>Please enter your password to confirm:</label>
                 <div class="ui input">
-                    <input type="password" name="password" required>
+                    <input type="password" name="password" data-testid="delete-account-password-input" required>
                 </div>
             </div>
         </form>
     </div>
     <div class="actions">
         <div class="ui cancel button">Cancel</div>
-        <button type="submit" form="delete-account-form" class="ui negative button">
+        <button type="submit" form="delete-account-form" class="ui negative button" data-testid="delete-account-confirm-btn">
             Delete My Account
         </button>
     </div>

--- a/src/webapp/templates/register.html
+++ b/src/webapp/templates/register.html
@@ -13,22 +13,22 @@
                 <div class="field">
                     <div class="ui left icon input">
                         <i class="user icon"></i>
-                        <input type="text" name="username" placeholder="Username" required>
+                        <input type="text" name="username" placeholder="Username" data-testid="register-username" required>
                     </div>
                 </div>
                 <div class="field">
                     <div class="ui left icon input">
                         <i class="lock icon"></i>
-                        <input type="password" name="password" placeholder="Password" required>
+                        <input type="password" name="password" placeholder="Password" data-testid="register-password" required>
                     </div>
                 </div>
                 <div class="field">
                     <div class="ui left icon input">
                         <i class="lock icon"></i>
-                        <input type="password" name="confirm_password" placeholder="Confirm Password" required>
+                        <input type="password" name="confirm_password" placeholder="Confirm Password" data-testid="register-confirm-password" required>
                     </div>
                 </div>
-                <button class="ui fluid large teal submit button" type="submit">Sign Up</button>
+                <button class="ui fluid large teal submit button" type="submit" data-testid="register-submit">Sign Up</button>
             </div>
             <div class="ui error message" id="error-message" style="display: none;">
                 <div class="header">Error</div>

--- a/test/webapp/pages/login_page.py
+++ b/test/webapp/pages/login_page.py
@@ -10,9 +10,14 @@ class LoginPage(BaseAppPage):
 
     def __init__(self, driver):
         super().__init__(driver)
+        self._visit("/login")
 
     def login(self, username, password):
         self._click(self.login_link_locator)
         self._type(self.username_field_locator, username)
         self._type(self.password_field_locator, password)
         self._click(self.login_button_locator)
+
+        # wait to be at the post-login page
+        self.wait_for_url('contains', '/todos')
+

--- a/test/webapp/pages/user_account_page.py
+++ b/test/webapp/pages/user_account_page.py
@@ -1,0 +1,21 @@
+from pages.base_app_page import BaseAppPage
+from pages.base_page import testid_locator
+
+
+class AccountPage(BaseAppPage):
+    # Locators
+    delete_button_locator = testid_locator("delete-account-btn")
+    confirm_password_input_locator = testid_locator("delete-account-password-input")
+    confirm_delete_button_locator = testid_locator("delete-account-confirm-btn")
+
+    def __init__(self, driver):
+        super().__init__(driver)
+        self._visit("/account")
+
+    def delete_account(self, password):
+        self._click(self.delete_button_locator)
+        self._wait_until(lambda d: self._is_displayed(self.confirm_password_input_locator))
+        self._type(self.confirm_password_input_locator, password)
+        self._click(self.confirm_delete_button_locator)
+        # Wait for redirect to login page
+        self.wait_for_url('contains', '/login')

--- a/test/webapp/pages/user_registration_page.py
+++ b/test/webapp/pages/user_registration_page.py
@@ -1,0 +1,21 @@
+from pages.base_app_page import BaseAppPage
+from pages.base_page import testid_locator
+
+
+class RegistrationPage(BaseAppPage):
+    username_input_locator = testid_locator("register-username")
+    password_input_locator = testid_locator("register-password")
+    password_confirmation_locator = testid_locator("register-confirm-password")
+    register_button_locator = testid_locator("register-submit")
+
+    def __init__(self, driver):
+        super().__init__(driver)
+        self._visit("/register")
+
+    def register_new_user(self, username, password):
+        self._type(self.username_input_locator, username)
+        self._type(self.password_input_locator, password)
+        self._type(self.password_confirmation_locator, password)
+        self._click(self.register_button_locator)
+        # Wait for redirect to login page
+        self.wait_for_url('contains', '/login')

--- a/test/webapp/tests/conftest.py
+++ b/test/webapp/tests/conftest.py
@@ -4,8 +4,11 @@ from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from environments.environment_data import Environment
 import os
+import random
 
 from pages.login_page import LoginPage
+from pages.user_registration_page import RegistrationPage
+from pages.user_account_page import AccountPage
 
 
 def pytest_addoption(parser):
@@ -19,21 +22,25 @@ def pytest_addoption(parser):
                      help="Run tests with browser in headless mode")
 
 
-@pytest.fixture
-def driver(request):
+def setup_webdriver(request):
+    """
+    Helper function to set up a WebDriver with proper configuration
+    """
+    headless = request.config.getoption("--headless") != "False"
     service = Service()
     options = webdriver.ChromeOptions()
-    if request.config.getoption("--headless") != "False":
+    if headless:
         options.add_argument('--headless')
 
         # Magical Config args:
         # SOME(not all) selectors break if you don't set window size. on headless mode.
         options.add_argument('window-size=1920x1080')
         # Browser will not be initialized in bitbucket pipelines without this config argument
+        # may be able to get away without it in other platforms.
         options.add_argument('--no-sandbox')
 
-    driver_ = webdriver.Chrome(service=service, options=options)
-    driver_.maximize_window()
+    driver = webdriver.Chrome(service=service, options=options)
+    driver.maximize_window()
 
     test_environment = request.config.getoption("--env")
     test_env_filename = os.path.join("environments", f"{test_environment}")
@@ -41,15 +48,19 @@ def driver(request):
 
     Environment.parse_environment_file(test_env_filename)
 
-    # Construct the base URL dynamically from the environment file.
     protocol = Environment.get_value("protocol")
     host = Environment.get_value("host")
     port = Environment.get_value("port")
 
-    driver_.base_url = f"{protocol}://{host}:{port}"
-    # sometimes we still need the raw hostname.
-    # better to just store it now instead of trying to regex it out later.
-    driver_.base_domain = host
+    driver.base_url = f"{protocol}://{host}:{port}"
+    driver.base_domain = host
+
+    return driver
+
+
+@pytest.fixture
+def driver(request):
+    driver_ = setup_webdriver(request)
 
     def quit_browser():
         driver_.quit()
@@ -58,16 +69,46 @@ def driver(request):
     return driver_
 
 
+@pytest.fixture(scope="session")
+def test_user_credentials():
+    # tack a random int onto the user and pass to avoid collisions
+    # just in case we fail to delete a user somehow.
+    session_rand_int = random.randint(0,9999)
+    session_username = f"test_user{session_rand_int}"
+    session_password = f"test_user{session_rand_int}"
+
+    return {"username": session_username, "password": session_password}
+
+
+@pytest.fixture(scope="session")
+def registered_user(test_user_credentials, request):
+    """
+    Create a user once before any tests run, to be used for all tests and deleted after
+    """
+    driver = setup_webdriver(request)
+
+    try:
+        registration_page = RegistrationPage(driver)
+        registration_page.register_new_user(
+            test_user_credentials["username"],
+            test_user_credentials["password"]
+        )
+    finally:
+        driver.quit()
+
+    return test_user_credentials
+
+
 @pytest.fixture
-def login(driver):
+def login(driver, registered_user):
     """
     Fixture to log in before a test begins
     """
     login_page = LoginPage(driver)
-    login_page._visit(driver.base_url)
 
-    username = "lelda"
-    password = "lelda"
+    username = registered_user["username"],
+    password = registered_user["password"]
+
     login_page.login(username, password)
     return driver
 
@@ -77,3 +118,29 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     result = outcome.get_result()
     setattr(item, "result_" + result.when, result)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_registered_user(test_user_credentials, request):
+    """
+    Cleanup fixture - runs after all tests, deletes the test user
+    """
+    # yield here so we can run a teardown procedure after all tests
+    yield
+
+    # now all tests should be done; log in and delete the user
+    driver = setup_webdriver(request)
+    username = test_user_credentials["username"],
+    password = test_user_credentials["password"]
+
+    try:
+        login_page = LoginPage(driver)
+        login_page.login(username, password)
+
+        account_page = AccountPage(driver)
+        account_page.delete_account(password)
+    except Exception as e:
+        print(f"Failed to delete test user {username}: {e}")
+    finally:
+        driver.quit()
+


### PR DESCRIPTION
Previously the test suite would assume the existence of a test user with hardcoded credentials. 

Now we have a setup fixture that creates a user before any tests are run,
a credentials fixture that passes the username and password into the login function for all tests,
and a teardown fixture that deletes the account after testing is complete. 

This will keep the database clean. 
Assuming the existence of a test user is brittle, tests can break because of changes to the DB
Creating a user and then not deleting it would eventually pollute the db with a heap of garbage users.

Test user data may be useful for diagnostic purposes, but if we need that then we can build it in, either by saving the test user somehow or commenting out the deletion fixture, but I doubt we'll ever need that.